### PR TITLE
RSDK-10365 Pin bluez installation to 5.82

### DIFF
--- a/etc/install_bluez.sh
+++ b/etc/install_bluez.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# Install bluez from source. The Viam SOCKS proxy bridge requires a bluez version >= 5.60.
+# Install version 5.82 bluez from source.
 
 echo "This script will install the latest bluez from source"
-echo "WARNING: This script has only been tested on radxa rock images of Debian 11."
+echo "WARNING: This script has only been tested on"
+echo "- Radxa rock images of Debian 11"
+echo "- Raspberry Pi images of Debian 12"
 
 while true; do
   echo "Do you want to proceed? (y/n)"
@@ -39,11 +41,14 @@ sudo apt install python3-docutils
 echo "Installing git (likely already installed)..."
 sudo apt install git
 
-echo "Cloning the latest bluez..."
+echo "Cloning bluez..."
 pushd ~
 git clone https://github.com/bluez/bluez.git
 
 pushd bluez
+echo "Checking out commit hash of version v5.82..."
+# Slightly hacky to checkout a hash, but bluez does not use git tags.
+git checkout 0efa20cbf3fb5693c7c2f14ba8cf67053ca029e5
 echo "Installing bluez requirements..."
 sudo apt-get build-dep bluez
 echo "Bootstrapping..."
@@ -59,5 +64,5 @@ echo "Unmasking, enabling, and restarting bluetooth service"
 sudo systemctl unmask bluetooth
 sudo systemctl enable bluetooth
 sudo systemctl restart bluetooth
-echo "Latest bluez installation successful. Use `bluetoothctl version` to verify version."
+echo "bluez v5.82 installation successful. Use `bluetoothctl version` to verify version."
 echo "Remember to run hciattach commands if using external bluetooth adapters."


### PR DESCRIPTION
Pins the installation of bluez to 5.82 so we don't run into further weird versioning issues. Previously we were installing whatever version was at the head of `main`, but [a bug in 5.81](https://github.com/bluez/bluez/commit/da5846c096cd1006d512bbdbc466fc46a61417b8) proves this is not a good strategy.